### PR TITLE
Add Bullet Physics and ARCore in license page

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -10,3 +10,5 @@ The following open source software supports SXR SDK:
 * [Assimp v3.1 Open Asset Import Library](http://assimp.sourceforge.net/main_license.html)
 * [Libpng v1.2.45 PNG Reference Library](http://www.libpng.org/pub/png/libpng.html)
 * [GLM v0.9.6.3 OpenGL Mathematics library](http://glm.g-truc.net/0.9.6/index.html) Licensed under [The Happy Bunny License and MIT License](http://glm.g-truc.net/copying.txt)
+* [Bullet Physics v3](https://github.com/bulletphysics/bullet3) Licensed under [Zlib License](https://github.com/bulletphysics/bullet3/blob/master/LICENSE.txt)
+* [ARCore Android SDK](https://developers.google.com/ar/develop/java/quickstart) Licensed under [Apache License v2.0](https://github.com/google-ar/arcore-android-sdk/blob/master/LICENSE)


### PR DESCRIPTION
Add information for both libraries that are being used in SXR as extensions.